### PR TITLE
Report error on checkout failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,12 @@ inquirer.prompt([
     if (!selection.confirm) {
       return process.exit(0)
     }
-    module.exports = exec(`git checkout ${branchSelection}`)
+    module.exports = exec(`git checkout ${branchSelection}`,
+    (error) => {
+      if (error) {
+        console.error(`${error}`);
+        return;
+      }
+    })
   })
 })


### PR DESCRIPTION
Hi! I LOVE this tool. I'm already feeling like I can't live without it haha. I found some behavior I was interested in changing though and thought I'd take a stab at a solution. Here's the breakdown.

Prior to this commit if checking out the selected branch failed, it did so silently. Which confused me! For instance, if there is an uncommited change on the current branch and you use the `checkout` command the branch doesn't change and we don't know why!

You may have a totally different preference for how to tackle this issue, I'm totally up for suggestions and any revision requests!

My solution is a version of the error capturing solution found in the documentation for child_process.exec()` found here https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback

In order to preserve the existing behavior, this commit opts to discard stdout and stderr in favor of verbosity only in reporting errors in exec.

Thanks for taking a look and for any feedback!